### PR TITLE
Update the Interep V2 endpoints and fix tests

### DIFF
--- a/rln-client-lib/tests/chat/chat.test.ts
+++ b/rln-client-lib/tests/chat/chat.test.ts
@@ -196,20 +196,22 @@ describe('Chat test', () => {
         expect(sendMessageSpy).toHaveBeenCalledTimes(1);
         expect(sendMessageSpy).toHaveBeenCalledWith(JSON.stringify({
             "zk_proof": {
-                "proof": {
-                    "pi_a": "pi_a",
-                    "pi_b": "pi_b",
-                    "pi_c": "pi_c",
-                    "protocol": "p",
-                    "curve": "c"
-                },
-                "publicSignals": {
-                    "yShare": BigInt(123).toString(),
-                    "merkleRoot": BigInt(123).toString(),
-                    "internalNullifier": BigInt(123).toString(),
-                    "signalHash": BigInt(123).toString(),
-                    "epoch": BigInt(123).toString(),
-                    "rlnIdentifier": BigInt(123).toString()
+                "fullProof": {
+                    "proof": {
+                        "pi_a": "pi_a",
+                        "pi_b": "pi_b",
+                        "pi_c": "pi_c",
+                        "protocol": "p",
+                        "curve": "c"
+                    },
+                    "publicSignals": {
+                        "yShare": BigInt(123).toString(),
+                        "merkleRoot": BigInt(123).toString(),
+                        "internalNullifier": BigInt(123).toString(),
+                        "signalHash": BigInt(123).toString(),
+                        "epoch": BigInt(123).toString(),
+                        "rlnIdentifier": BigInt(123).toString()
+                    }
                 }
             },
             "x_share": "111",

--- a/server/src/interrep/api.ts
+++ b/server/src/interrep/api.ts
@@ -24,26 +24,26 @@ const getAllGroups = async (): Promise<IInterRepGroupV2[]> => {
 /**
  * Returns an ordered list of members in the group.
  */
-const getMembersForGroup = async (groupHash: string, limit: number = 100, offset: number = 0): Promise<IGroupMember[]> => {
+const getMembersForGroup = async (provider: string, name: string, limit: number = 100, offset: number = 0): Promise<IGroupMember[]> => {
     try {
         const res = await axios({
             method: 'GET',
             timeout: 5000,
-            url: config.INTERREP_V2 + `/trees/${groupHash}?limit=${limit}&offset=${offset}`,
+            url: config.INTERREP_V2 + `/groups/${provider}/${name}?members=true&limit=${limit}&offset=${offset}`,
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
             }
         });
         
-        return res.data.data.map((el, index) => {
+        return res.data.data.members.map((el, index) => {
             return {
                 index: offset + index,
                 identityCommitment: el
             }
         });
     } catch (e) {
-        console.log("Exception while loading group: ", groupHash);
+        console.log("Exception while loading group: ", provider, name);
         return [];
     }
 }

--- a/server/tests/interrep/api.test.ts
+++ b/server/tests/interrep/api.test.ts
@@ -62,11 +62,19 @@ describe('Test interrep sync - subgraph', () => {
 
         mockAxios.mockResolvedValue({
             data: {
-                data: testMembers_g1
+                data: {
+                    provider: "twitter",
+                    name: "not_sufficient",
+                    depth: 20,
+                    root: "3282736528510229708245753028800701559160032734733920390753117377915762630937",
+                    size: 6,
+                    numberOfLeaves: 6,
+                    members: testMembers_g1
+                }
             }
         });
 
-        const members: IGroupMember[] = await apiFunctions.getMembersForGroup("id1");
+        const members: IGroupMember[] = await apiFunctions.getMembersForGroup("twitter", "not_sufficient");
         expect(members.length).toEqual(6);
         expect(members[0]).toEqual({ index: 0, identityCommitment: 'id-0' });
         expect(members[1]).toEqual({ index: 1, identityCommitment: 'id-1' });


### PR DESCRIPTION
Update the interep endpoints to `api/v1/...`, respective calling code and tests